### PR TITLE
Strip some trailing puctuations from final URL

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -175,7 +175,7 @@ end
 
 local function open_url(url)
     core.log("Opening %s...", url)
-    os.execute(string.format('%s %s', config.plugins.link_opener.filelauncher, url))
+    system.exec(string.format('%s %s', config.plugins.link_opener.filelauncher, url))
 end
 
 local docview_predicate = command.generate_predicate("core.docview")


### PR DESCRIPTION
Strips punctuation that is normally not found at the end of a url, these are: . , ]

Fixes matching urls like the one in screeny:

<img width="582" height="81" alt="20250711-170817" src="https://github.com/user-attachments/assets/f1f304ee-2139-4250-9f75-eb33b1f9ae33" />


**Edit:** 
Also noted from an old comment that the command prompt was been shown on Windows while opening the link, also had the same issue with the source control management plugin where I used io.popen to execute a simple git command that caused a lot of cmd windows to appear momentarily, had a hard time noticing what was the cause :) In the end Lua uses standard C functions to handle process execution and on windows this means launching a separate annoying cmd window, so replaced `os.execute` with `system.exec`.